### PR TITLE
Save log output to results dir

### DIFF
--- a/xemutest/__main__.py
+++ b/xemutest/__main__.py
@@ -7,7 +7,6 @@ import sys
 
 import xemutest
 
-logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__file__)
 
 
@@ -38,6 +37,11 @@ def main():
 				tests.append((test_name, test_class))
 
 	results_root = os.path.abspath(os.path.expanduser(args.results))
+	os.makedirs(results_root, exist_ok=True)
+
+	log_file_name = os.path.join(results_root, "xemutest.log")
+	logging.basicConfig(filename=log_file_name, filemode='w', level=logging.INFO)
+
 	if args.data:
 		test_data_root = os.path.expanduser(args.data)
 	else:

--- a/xemutest/test_base.py
+++ b/xemutest/test_base.py
@@ -219,7 +219,7 @@ class TestBase:
 		self._terminate_video_capture()
 
 	def _mount_hdd(self):
-		log.info('Mounting HDD image')
+		log.info(f'Mounting HDD image {self.hdd_path} at {self.mount_path}')
 		if os.path.exists(self.mount_path):
 			shutil.rmtree(self.mount_path)
 		os.makedirs(self.mount_path, exist_ok=True)


### PR DESCRIPTION
Intended to streamline debugging a bit by saving the log to a file in the same place as the test artifacts.

Bonus: Extends the logging on the image mount so there's clarity as to the paths involved.